### PR TITLE
remove dot-ui ref

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -102,8 +102,8 @@ and this project adheres to
 
 - Updated documentation to use "polkadot-ui" branding consistently
 - Updated all CLI command examples to use `polkadot-ui` instead of `dot-ui`
-- Updated registry URLs to use dot-ui.com (production domain)
-- Maintained internal references to dot-ui for consistency
+- Updated registry URLs to use polkadot-ui.com (production domain)
+- Maintained internal references to polkadot-ui for consistency
 
 ### Fixed
 
@@ -115,7 +115,7 @@ and this project adheres to
 
 ### Added
 
-- Initial alpha release of dot-ui CLI
+- Initial alpha release of polkadot-ui CLI
 - **`init` command** - Initialize new projects with Polkadot UI components
   - Interactive project setup with framework selection (Next.js/Vite)
   - Automatic TypeScript, ESLint, and Tailwind CSS configuration
@@ -177,7 +177,7 @@ and this project adheres to
 
 ### Registry Integration
 
-- Fetches components from dot-ui.com registry
+- Fetches components from polkadot-ui.com registry
 - Support for custom registry URLs
 - Automatic component validation
 - Registry dependency resolution

--- a/packages/cli/src/utils/telemetry.ts
+++ b/packages/cli/src/utils/telemetry.ts
@@ -382,11 +382,11 @@ export class Telemetry {
       console.log("\n📊 Privacy Notice");
       console.log("================");
       console.log(
-        "dot-ui collects anonymous usage data to help improve the tool."
+        "polkadot-ui collects anonymous usage data to help improve the tool."
       );
       console.log("No personal information or project data is collected.");
       console.log(
-        "Run 'dot-ui telemetry info' for details or 'dot-ui telemetry disable' to opt out."
+        "Run 'polkadot-ui telemetry info' for details or 'polkadot-ui telemetry disable' to opt out."
       );
       console.log(
         "Set DOT_UI_DISABLE_TELEMETRY=true to disable permanently.\n"

--- a/packages/registry/app/docs/components/require-connection.mdx
+++ b/packages/registry/app/docs/components/require-connection.mdx
@@ -173,7 +173,7 @@ The component handles three distinct states:
 
 ## Supported Chain IDs
 
-The component works with any chain ID configured in your dot-ui config:
+The component works with any chain ID configured in your polkadot-ui config:
 
 - `"paseo"` - Paseo Relay Chain
 - `"paseoPeople"` - Paseo People Chain

--- a/packages/registry/app/page.tsx
+++ b/packages/registry/app/page.tsx
@@ -1,5 +1,12 @@
 import { HeroSection } from "@/components/layout/hero-section";
 import { ComponentsSection } from "@/components/layout/components-section";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Polkadot UI - UX first Web3 React Components with MCP",
+  description:
+    "Beautiful, accessible components for the Polkadot ecosystem. Type-safe, customizable, and built with modern React patterns.",
+};
 
 export default async function Home() {
   return (

--- a/packages/registry/components/feedback-toast.tsx
+++ b/packages/registry/components/feedback-toast.tsx
@@ -23,7 +23,9 @@ export function FeedbackToast() {
             <div className="flex flex-row items-center gap-3">
               <Heart className="h-5 w-5 text-pink-500 flex-shrink-0" />
               <div className="flex-1">
-                <p className="font-medium text-sm">Help us improve dot-ui!</p>
+                <p className="font-medium text-sm">
+                  Help us improve polkadot-ui!
+                </p>
                 <p className="text-xs text-muted-foreground">
                   Share your feedback and help shape the future of Web3 UI
                   components


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added page metadata (title and description) to the registry app for clearer titles and improved SEO.

- Documentation
  - Updated references from “dot-ui” to “polkadot-ui” across the changelog and docs, including “Supported Chain IDs” wording.

- Chores
  - Refreshed branding in user-facing messages: CLI telemetry notices and the site’s feedback toast now reference “polkadot-ui.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->