### PR TITLE
Fix: select text invisible on hover (light mode)

### DIFF
--- a/packages/registry/app/globals.css
+++ b/packages/registry/app/globals.css
@@ -70,7 +70,7 @@
   --muted: oklch(0.97 0 0);
   --muted-foreground: oklch(0.556 0 0);
   --accent: oklch(0.985 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the accent foreground color used globally across the app.
  * Affects visual appearance of buttons, links, badges, toggles, and other accent-driven elements in all themes.
  * Text and icons that rely on the accent color will render with a darker tone.
  * No changes to layout, interactions, or component structure.
  * Applies uniformly in light and dark modes for consistent presentation across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->